### PR TITLE
Replace BouncyCastle lib to support Blazor Wasm

### DIFF
--- a/src/Standard.Licensing/Standard.Licensing.csproj
+++ b/src/Standard.Licensing/Standard.Licensing.csproj
@@ -52,6 +52,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Standard.Licensing library doesn't want to work in a Blazor WebAssembly project under Web Browser (freezing on signature verification). The issue is related with the currently used Bouncy Castle library (`BouncyCastle.NetCore`).

I've replaced this library to another fork, which is also maintainable nowadays and (probably) official: `Portable.BouncyCastle`.